### PR TITLE
Feat: raise notification with errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
     "@material-ui/core": "^4.11.0",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/styles": "^4.10.0",
     "@reduxjs/toolkit": "^1.4.0",
     "@testing-library/jest-dom": "^4.2.4",

--- a/src/components/ButtonsContainer/index.jsx
+++ b/src/components/ButtonsContainer/index.jsx
@@ -11,7 +11,7 @@ import {
 import {
     selectCode,
     updateRegisters,
-    // updateMemory,
+    raiseError,
 } from 'slices/emulatorSlice';
 import emulator from 'emulator/emulator';
 
@@ -43,10 +43,18 @@ export default function ButtonsContainer() {
     };
 
     const stepClick = () => {
-        loadCode();
-        emulator.cpu.step();
-        dispatch(updateRegisters(emulator.getRegisters()));
-        // dispatch(updateMemory(emulator.getMemory()));
+        try {
+            loadCode();
+            emulator.cpu.step();
+            dispatch(updateRegisters(emulator.getRegisters()));
+        } catch (err) {
+            dispatch(raiseError({
+                message: err.message,
+                position: err.position,
+                name: err.name,
+                lineNumber: err.lineNumber,
+            }));
+        }
     };
 
     return (

--- a/src/components/ButtonsContainer/index.jsx
+++ b/src/components/ButtonsContainer/index.jsx
@@ -49,9 +49,10 @@ export default function ButtonsContainer() {
             dispatch(updateRegisters(emulator.getRegisters()));
         } catch (err) {
             dispatch(raiseError({
+                name: err.name,
+                token: err.token,
                 message: err.message,
                 position: err.position,
-                name: err.name,
                 lineNumber: err.lineNumber,
             }));
         }

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -47,7 +47,6 @@ export default function Editor() {
                 mode="assembly_x86"
                 fontSize="1rem"
                 theme="dracula"
-                cursorStart={6}
                 onChange={onChange}
                 value={codeStorage || defaultMsg}
                 showPrintMargin={false}

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -7,6 +7,7 @@ import 'ace-builds/src-noconflict/theme-dracula';
 
 import { updateCode } from 'slices/emulatorSlice';
 import ButtonsContainer from 'components/ButtonsContainer';
+import NotificationError from 'components/NotificationError';
 
 export default function Editor() {
     const dispatch = useDispatch();
@@ -25,6 +26,8 @@ export default function Editor() {
 
     return (
         <div>
+            <NotificationError />
+
             <ButtonsContainer />
 
             <AceEditor

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -1,16 +1,29 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import AceEditor from 'react-ace';
 import 'ace-builds/src-noconflict/mode-assembly_x86';
 import 'ace-builds/src-noconflict/theme-dracula';
 
-import { updateCode } from 'slices/emulatorSlice';
+import { updateCode, selectError, selectCode } from 'slices/emulatorSlice';
 import ButtonsContainer from 'components/ButtonsContainer';
 import NotificationError from 'components/NotificationError';
 
 export default function Editor() {
     const dispatch = useDispatch();
+
+    const error = useSelector(selectError);
+    const codeStorage = useSelector(selectCode);
+    let annotation = {};
+
+    if (error.isRaised) {
+        annotation = {
+            row: error.lineNumber - 1,
+            column: 0,
+            type: 'error',
+            text: `${error.name}: ${error.message || error.token}`,
+        };
+    }
 
     const onChange = (code) => {
         dispatch(updateCode(code));
@@ -34,12 +47,14 @@ export default function Editor() {
                 mode="assembly_x86"
                 fontSize="1rem"
                 theme="dracula"
+                cursorStart={6}
                 onChange={onChange}
-                value={defaultMsg}
+                value={codeStorage || defaultMsg}
                 showPrintMargin={false}
                 height="100vh"
                 width="50vw"
                 name="editor"
+                annotations={[annotation]}
                 editorProps={{ $blockScrolling: true }}
             />
         </div>

--- a/src/components/NotificationError/index.jsx
+++ b/src/components/NotificationError/index.jsx
@@ -24,6 +24,20 @@ export default function NotificationError() {
                 <AlertTitle>
                     {`${error.name}: ${error.message}`}
                 </AlertTitle>
+
+                {
+                    error.position
+                        ? (
+                            <>
+                                Please check out line:
+                                <strong>
+                                    {` ${error.lineNumber}`}
+                                </strong>
+                            </>
+                        )
+                        : null
+                }
+
             </Alert>
         </Collapse>
     );

--- a/src/components/NotificationError/index.jsx
+++ b/src/components/NotificationError/index.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+    clearError,
+    selectError,
+} from 'slices/emulatorSlice';
+
+// components
+import Alert from '@material-ui/lab/Alert';
+import AlertTitle from '@material-ui/lab/AlertTitle';
+import Collapse from '@material-ui/core/Collapse';
+
+export default function NotificationError() {
+    const dispatch = useDispatch();
+    const error = useSelector(selectError);
+
+    const closeNotification = () => {
+        dispatch(clearError());
+    };
+
+    return (
+        <Collapse in={error.isRaised}>
+            <Alert severity="error" onClose={closeNotification}>
+                <AlertTitle>
+                    {`${error.name}: ${error.message}`}
+                </AlertTitle>
+            </Alert>
+        </Collapse>
+    );
+}

--- a/src/components/NotificationError/index.jsx
+++ b/src/components/NotificationError/index.jsx
@@ -22,7 +22,7 @@ export default function NotificationError() {
         <Collapse in={error.isRaised}>
             <Alert severity="error" onClose={closeNotification}>
                 <AlertTitle>
-                    {`${error.name}: ${error.message}`}
+                    {`${error.name}: ${error.message || error.token}`}
                 </AlertTitle>
 
                 {

--- a/src/emulator/parser/lexer.js
+++ b/src/emulator/parser/lexer.js
@@ -144,6 +144,7 @@ export default class Lexer {
         }
 
         throw new InvalidTokenError({
+            token: upperCaseTok,
             position: this.position,
             lineNumber: this.lineNumber,
         });
@@ -185,6 +186,7 @@ export default class Lexer {
         }
 
         throw new InvalidTokenError({
+            token: upperCaseTok,
             position: this.position,
             lineNumber: this.lineNumber,
         });
@@ -258,6 +260,7 @@ export default class Lexer {
         }
 
         throw new InvalidTokenError({
+            token: c,
             position: this.position,
             lineNumber: this.lineNumber,
         });

--- a/src/emulator/parser/models/errors.js
+++ b/src/emulator/parser/models/errors.js
@@ -1,9 +1,10 @@
 export class InvalidTokenError extends Error {
-    constructor({ position, lineNumber }) {
+    constructor({ token, position, lineNumber }) {
         super();
         this.name = 'Invalid Token';
         this.position = position;
         this.lineNumber = lineNumber;
+        this.token = token;
     }
 }
 

--- a/src/slices/emulatorSlice.js
+++ b/src/slices/emulatorSlice.js
@@ -5,6 +5,9 @@ const initialState = {
     registers: emulator.getRegisters(),
     memory: emulator.getMemory(),
     code: '',
+    error: {
+        isRaised: false,
+    },
 };
 
 const emulatorSlice = createSlice({
@@ -20,13 +23,26 @@ const emulatorSlice = createSlice({
         updateMemory(state, action) {
             state.memory = action.payload;
         },
+        raiseError(state, action) {
+            state.error = { isRaised: true, ...action.payload };
+        },
+        clearError(state) {
+            state.error = { isRaised: false };
+        },
     },
 });
 
 export const selectCode = (state) => state.emulator.code;
 export const selectMemory = (state) => state.emulator.memory;
 export const selectRegisters = (state) => state.emulator.registers;
+export const selectError = (state) => state.emulator.error;
 
-export const { updateCode, updateRegisters, updateMemory } = emulatorSlice.actions;
+export const {
+    updateCode,
+    updateRegisters,
+    updateMemory,
+    raiseError,
+    clearError,
+} = emulatorSlice.actions;
 
 export default emulatorSlice.reducer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1416,6 +1416,17 @@
     react-is "^16.8.0"
     react-transition-group "^4.4.0"
 
+"@material-ui/lab@^4.0.0-alpha.56":
+  version "4.0.0-alpha.56"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz#ff63080949b55b40625e056bbda05e130d216d34"
+  integrity sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.10.2"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0"
+
 "@material-ui/styles@^4.10.0":
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.10.0.tgz#2406dc23aa358217aa8cc772e6237bd7f0544071"


### PR DESCRIPTION
A notification is fired at the top of the editor when an error occurs, printing the type of error, the description of the error and adding an annotation on the line where the error occurred.

The `Notification Error` component was created that contains the alert that will be launched when there is an error in the storage and the` error` slice where the error will be saved as an object.

The `SyntaxError` class was modified by adding a new` token` attribute which indicates the instruction that caused the parser to throw the error, with the `token` attribute the error can be specified in more

This is how it looks when a `Syntax Errror` is launched:
<img width="681" alt="Screen Shot 2020-09-25 at 12 15 41 PM" src="https://user-images.githubusercontent.com/23442814/94291038-0ae8ea80-ff29-11ea-9d5f-479cc50db0ac.png">

Fix issue #15 


